### PR TITLE
イベント、ショップの画像の追加、削除ができるようにした

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -31,10 +31,11 @@ class EventsController < ApplicationController
   end
 
   def update
-    if @event.update(event_params)
+    if @event.update(event_params.except(:images))
+      @event.images.attach(event_params[:images]) if event_params[:images].present?
       redirect_to @event, notice: "イベントを更新しました。"
     else
-      flash.now[:alert] = "イベントの更新に失敗しました。入力内容を確認してください。"
+      flash.now[:alert] = "更新に失敗しました。"
       render :edit, status: :unprocessable_entity
     end
   end
@@ -44,6 +45,14 @@ class EventsController < ApplicationController
     redirect_to events_path, notice: "イベントを削除しました。", status: :see_other
   end
 
+  def destroy_image
+    @event = current_user.events.find(params[:id])
+    image = @event.images.find(params[:image_id])
+
+    image.purge
+
+    redirect_to edit_event_path(@event), notice: "画像を削除しました。"
+  end
   private
 
   def event_params

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -29,7 +29,8 @@ class ShopsController < ApplicationController
   end
 
   def update
-    if @shop.update(shop_params)
+    if @shop.update(shop_params.except(:images))
+      @shop.images.attach(shop_params[:images]) if shop_params[:images].present?
       redirect_to @shop, notice: "店舗情報を更新しました。"
     else
       flash.now[:alert] = "店舗情報の更新に失敗しました。入力内容を確認してください。"
@@ -40,6 +41,13 @@ class ShopsController < ApplicationController
   def destroy
     @shop.destroy
     redirect_to shops_path, notice: "店舗を削除しました。", status: :see_other
+  end
+
+  def destroy_image
+    @shop = current_user.shops.find(params[:id])
+    image = @shop.images.find(params[:image_id])
+    image.purge
+    redirect_to edit_shop_path(@shop), notice: "画像を削除しました。"
   end
 
   private

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -117,8 +117,19 @@
         <p class="text-xs text-slate-500 mt-1">登録済みの画像：</p>
         <div class="mt-2 flex flex-wrap gap-2">
           <% event.images.each do |image| %>
-            <%= image_tag image.variant(resize_to_fill: [160, 100]),
-                  class: "h-24 w-40 rounded object-cover border" %>
+            <% next unless image.persisted? %>
+            <div class="relative group">
+              <%= image_tag image.variant(resize_to_fill: [160, 100]),
+                    class: "h-24 w-40 rounded object-cover border" %>
+
+              <%= link_to "×",
+                    image_event_path(event, image_id: image.id),
+                    data: {
+                      turbo_method: :delete,
+                      turbo_confirm: "この画像を削除しますか？"
+                    },
+                    class: "absolute -top-2 -right-2 h-6 w-6 rounded-full bg-black text-white text-xs font-bold flex items-center justify-center opacity-0 group-hover:opacity-100 transition" %>
+            </div>
           <% end %>
         </div>
       <% end %>

--- a/app/views/shops/_form.html.erb
+++ b/app/views/shops/_form.html.erb
@@ -69,12 +69,20 @@
             accept: "image/*",
             class: "block w-full text-sm text-slate-700" %>
 
-      <% if @shop.images.attached? %>
+      <% if @shop.persisted? && @shop.images.attached? %>
         <p class="text-xs text-slate-500 mt-1">登録済みの画像：</p>
         <div class="mt-2 flex flex-wrap gap-2">
           <% @shop.images.each do |image| %>
-            <%= image_tag image.variant(resize_to_fill: [120, 120]),
-                  class: "h-20 w-20 rounded object-cover border" %>
+            <% next unless image.persisted? %>
+
+            <div class="relative group">
+              <%= image_tag image.variant(resize_to_fill: [120, 120]),
+                    class: "h-20 w-20 rounded object-cover border" %>
+
+              <%= link_to "×",image_shop_path(@shop, image_id: image.id),
+                data: { turbo_method: :delete, turbo_confirm: "この画像を削除しますか？" },
+                class: "absolute -top-2 -right-2 h-6 w-6 rounded-full bg-black text-white text-xs font-bold flex items-center justify-center opacity-0 group-hover:opacity-100 transition" %>
+            </div>
           <% end %>
         </div>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,18 +3,19 @@ Rails.application.routes.draw do
 
   devise_for :users
 
-  resources :shops, only: [ :index, :show, :new, :create, :edit, :update, :destroy ]
-  resources :events, only: [ :index, :show, :new, :create, :edit, :update, :destroy ]
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+  resources :events, only: %i[index show new create edit update destroy] do
+    member do
+      delete "images/:image_id", to: "events#destroy_image", as: :image
+    end
+  end
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
+  resources :shops, only: %i[index show new create edit update destroy] do
+    member do
+      delete "images/:image_id", to: "shops#destroy_image", as: :image
+    end
+  end
+
   get "up" => "rails/health#show", as: :rails_health_check
-
-  # Render dynamic PWA files from app/views/pwa/*
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-
-  # Defines the root path route ("/")
-  # root "posts#index"
 end


### PR DESCRIPTION
# 概要
ショップ、イベントの画像が編集時に消えてしまっていたため以下のように修正した。

既存の画像は消えずに新規画像を追加できる。
既存の画像を削除できる。