### PR TITLE
SassC エラー回避のため CSS コンプレッサを無効化(本番環境)

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,4 +102,5 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.assets.css_compressor = nil
 end


### PR DESCRIPTION
# 概要

本番環境の方もSassC エラー回避のため CSS コンプレッサを無効化