### PR TITLE
Deviseパスワード再設定の文言とUIを整備

### DIFF
--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,12 +1,15 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
-    <h2>
+  <div
+    id="error_explanation"
+    data-turbo-cache="false"
+    class="mb-4 rounded-md bg-red-50 border border-red-200 p-4 text-sm text-red-700">
+    <h2 class="font-semibold mb-1">
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
                  resource: resource.class.model_name.human.downcase)
        %>
     </h2>
-    <ul>
+    <ul class="list-disc list-inside space-y-0.5">
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>


### PR DESCRIPTION
## 概要

・パスワード再設定メール本文を日本語化
・リセット画面のUIをログイン画面と統一
・Deviseのエラー表示にスタイルを追加