### PR TITLE
イベントお気に入りのrequest spec追加

### DIFF
--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :event do
+    association :shop
+    title { "テストイベント" }
+    start_datetime { Time.zone.now + 1.day }
+    description { "テスト用イベントです" }
+  end
+end

--- a/spec/factories/shops.rb
+++ b/spec/factories/shops.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :shop do
+    association :user
+    sequence(:name) { |n| "テスト店舗#{n}" }
+    prefecture { "福岡県" }
+    city { "福岡市" }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :user do
+    sequence(:name)  { |n| "テストユーザー#{n}" }
+    sequence(:email) { |n| "user#{n}@example.com" }
+    password { "password123" }
+    password_confirmation { "password123" }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -70,11 +70,13 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+  config.include Devise::Test::IntegrationHelpers, type: :request
 
   Shoulda::Matchers.configure do |config|
-  config.integrate do |with|
-    with.test_framework :rspec
-    with.library :rails
+    config.integrate do |with|
+      with.test_framework :rspec
+      with.library :rails
+    end
   end
-end
+  abort("RAILS_ENV must be test!") unless Rails.env.test?
 end

--- a/spec/requests/event_favorites_spec.rb
+++ b/spec/requests/event_favorites_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe "Event favorites", type: :request do
+  let(:user) { create(:user) }
+
+  describe "POST /events/:event_id/favorite" do
+    it "未ログインはログインへ" do
+      event = create(:event)
+      post event_favorite_path(event)
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "ログイン済みはお気に入りできる" do
+      event = create(:event)
+      sign_in user
+      post event_favorite_path(event)
+      expect(response).to have_http_status(:found)
+    end
+  end
+
+  describe "DELETE /events/:event_id/favorite" do
+    it "ログイン済みは解除できる" do
+      event = create(:event)
+      sign_in user
+      post event_favorite_path(event)
+
+      delete event_favorite_path(event)
+      expect(response).to have_http_status(:found)
+    end
+  end
+end


### PR DESCRIPTION
## 概要

イベントのお気に入り（作成/解除）について、request spec を追加して挙動を固定しました。

### 変更内容
•spec/requests/event_favorites_spec.rb を追加
•未ログイン時はログイン画面へリダイレクト
•ログイン時はお気に入り作成/解除ができる
•テスト実行に必要なFactoryを追加/調整（user / shop / event）
•user.email を sequence にして重複を防止
•request specで sign_in を使えるように Devise IntegrationHelpers を追加
