### PR TITLE
P0-01の追補（DB増減）

### DIFF
--- a/spec/requests/event_favorites_spec.rb
+++ b/spec/requests/event_favorites_spec.rb
@@ -10,21 +10,24 @@ RSpec.describe "Event favorites", type: :request do
       expect(response).to redirect_to(new_user_session_path)
     end
 
-    it "ログイン済みはお気に入りできる" do
+    it "ログイン済みはお気に入りできる（DB増える）" do
       event = create(:event)
       sign_in user
-      post event_favorite_path(event)
+      expect {
+        post event_favorite_path(event)
+      }.to change(Favorite, :count).by(1)
       expect(response).to have_http_status(:found)
     end
   end
 
   describe "DELETE /events/:event_id/favorite" do
-    it "ログイン済みは解除できる" do
+    it "ログイン済みは解除できる（DB減る）" do
       event = create(:event)
       sign_in user
       post event_favorite_path(event)
-
-      delete event_favorite_path(event)
+      expect {
+        delete event_favorite_path(event)
+      }.to change(Favorite, :count).by(-1)
       expect(response).to have_http_status(:found)
     end
   end


### PR DESCRIPTION
## 概要
P0-01「Event Favorite（ログイン必須＋作成/解除）」の完了条件（DB増える/減る）に合わせて、
request spec を強化して仕様を固定する。

## 変更内容
- spec/requests/event_favorites_spec.rb
  - ログイン済みPOST：Favorite件数が +1 になることを検証
  - ログイン済みDELETE：Favorite件数が -1 になることを検証
  - 未ログイン時のログインリダイレクト確認は維持