### PR TITLE
fix: 画像6枚以上で作成不可を保証（テスト追加）

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -45,9 +45,10 @@ class EventsController < ApplicationController
     @event = @shop.events.build(event_params.except(:pro_player_ids, :images))
 
     ActiveRecord::Base.transaction do
+      @event.images.attach(event_params[:images]) if event_params[:images].present?
+
       @event.save!
       @event.pro_players = User.where(id: pro_player_ids)
-      @event.images.attach(event_params[:images]) if event_params[:images].present?
       create_new_event_notifications!(@event)
     end
 
@@ -64,10 +65,9 @@ class EventsController < ApplicationController
 
   def update
     ActiveRecord::Base.transaction do
+      @event.images.attach(event_params[:images]) if event_params[:images].present?
       @event.update!(event_params.except(:pro_player_ids, :images))
       @event.pro_players = User.where(id: pro_player_ids)
-
-      @event.images.attach(event_params[:images]) if event_params[:images].present?
     end
 
     redirect_to @event, notice: "イベントを更新しました。"

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Event, type: :model do
 
       expect(event).not_to be_valid
       expect(event.errors[:images]).to be_present
+      expect(event.errors[:images].join).to match(/5/)
     end
 
     it "画像が5枚までなら有効" do

--- a/spec/requests/events_images_validation_spec.rb
+++ b/spec/requests/events_images_validation_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "Events images validation", type: :request do
+  let(:owner) { create(:user) }
+  let(:shop)  { create(:shop, user: owner) }
+
+  let(:file_path) { Rails.root.join("spec/fixtures/files/sample.jpeg") }
+
+  def upload_file
+    Rack::Test::UploadedFile.new(file_path, "image/jpeg")
+  end
+
+  it "画像が6枚以上だと作成できず422" do
+    sign_in owner
+
+    params = {
+      event: {
+        title: "test",
+        shop_id: shop.id,
+        images: Array.new(6) { upload_file }
+      }
+    }
+
+    post events_path, params: params
+
+    expect(response).to have_http_status(:unprocessable_entity)
+  end
+end


### PR DESCRIPTION
## 概要
6枚以上の画像添付でもイベントが作成できてしまう挙動を修正し、最大5枚制限を保証する。

## 変更内容
- EventsController#create の画像添付順を修正（保存前にattach）
- 6枚以上で作成が失敗することをテスト追加で固定（422）

## 確認方法
- `docker compose exec -e RAILS_ENV=test web bundle exec rspec`
- 手動：6枚以上→作成失敗 / 5枚→作成成功