### PR TITLE
P0-07 メール送信失敗時の挙動を固定（イベント作成は継続）

### DIFF
--- a/spec/services/notifications/event_notification_service_spec.rb
+++ b/spec/services/notifications/event_notification_service_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe Notifications::EventNotificationService, type: :service do
+  let(:actor) { create(:user) }
+  let(:owner) { create(:user) }
+  let(:shop)  { create(:shop, user: owner) }
+  let(:event) { create(:event, shop: shop) }
+  let(:recipient) { create(:user) }
+
+  let(:context) { { reasons: [], pro_names: [], shop_name: shop.name } }
+
+  it "メール送信が例外でも落ちず :failed を返し、Sentryに送る" do
+    service = described_class.new(event, actor: actor)
+
+    allow(EventMailer).to receive_message_chain(:event_created, :deliver_later)
+      .and_raise(StandardError.new("boom"))
+
+    # Sentryがない環境でもテストが落ちないようにする
+    stub_const("Sentry", Class.new) unless defined?(Sentry)
+    allow(Sentry).to receive(:capture_exception)
+
+    result = service.event_created!(recipient, context)
+
+    expect(result).to eq(:failed)
+    expect(Sentry).to have_received(:capture_exception)
+  end
+end


### PR DESCRIPTION
## 概要
イベント作成時の通知メールが失敗してもイベント作成を止めず、原因追跡できる状態にする。

## 変更内容
- 通知メール送信処理で例外を握り、イベント作成は成功扱いで継続
- 失敗時にログへ追跡情報（event_id / recipient_id / dedupe_key など）を出力
- Sentryへ例外を送信（設定済み環境のみ）

## 確認方法
- rspec: `docker compose exec -e RAILS_ENV=test web bundle exec rspec`
- ローカルでメール失敗を再現し、Sentryに例外が上がることを確認

## 影響範囲
- 通知メール送信（失敗時の扱いのみ）
- イベント作成自体の成功/失敗条件は変更なし（メール失敗では失敗にしない）