### PR TITLE
Sentry送信をproductionのみに制限

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -2,4 +2,5 @@ Sentry.init do |config|
   config.dsn = ENV["SENTRY_DSN"]
   config.environment = ENV.fetch("SENTRY_ENVIRONMENT", Rails.env)
   config.breadcrumbs_logger = %i[active_support_logger http_logger]
+  config.enabled_environments = %w[production]
 end


### PR DESCRIPTION
## 概要
Sentryの通知がdevelopmentでも発生していたため、production環境のみ送信する設定にしました。