### PR TITLE
chore: events:update_statusに開始/終了/エラーログを追加

### DIFF
--- a/lib/tasks/events.rake
+++ b/lib/tasks/events.rake
@@ -1,6 +1,7 @@
 namespace :events do
   task update_status: :environment do
-    Rails.logger.info("[CRON] start events:update_status at=#{Time.current}")
+    started_at = Time.current
+    Rails.logger.info("[CRON] start events:update_status at=#{started_at}")
 
     Event.finish_past_events!
 


### PR DESCRIPTION
## 概要
Cron Job で実行している `events:update_status` タスクに、開始/終了/エラーログを追加。

## 目的
- Render の Cron Job ログから「実行されたか」「失敗したか」を即確認できるようにするため。

## 変更内容
- `lib/tasks/events.rake` の `events:update_status` に以下を追加
  - 実行開始ログ
  - 実行終了ログ
  - 例外発生時のエラーログ（例外は再raise）
