### PR TITLE
fix: イベント/ショップの住所表示をshop.address基準に統一

### DIFF
--- a/app/views/events/_card.html.erb
+++ b/app/views/events/_card.html.erb
@@ -45,7 +45,7 @@
       <div class="flex items-start gap-2">
         <span class="text-base mt-0.5 shrink-0">📍</span>
         <span class="text-sm text-slate-700 font-medium leading-snug">
-          <%= event.prefecture.presence || event.shop&.prefecture.presence || "未設定" %>
+          <%= event.shop&.address.to_s.strip.presence || "未設定" %>
         </span>
       </div>
     </div>

--- a/app/views/events/confirm.html.erb
+++ b/app/views/events/confirm.html.erb
@@ -59,7 +59,7 @@
         </section>
       <% end %>
 
-      <% full_address = [@event.prefecture, @event.city, @event.address].reject(&:blank?).join %>
+      <% full_address = @event.shop&.address.to_s.strip %>
 
       <div class="mb-6 text-sm text-slate-700 space-y-2">
         <% if full_address.present? %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -91,7 +91,7 @@
         </section>
       <% end %>
 
-      <% full_address = [@event.prefecture, @event.city, @event.address].compact.join %>
+      <% full_address = @event.shop&.address.to_s.strip %>
       
       <div class="mb-6 text-sm text-slate-700 space-y-2">
         <% if @event.location.present? %>

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -115,9 +115,10 @@
 
               <div class="p-4">
                 <%= link_to shop_path(shop), class: "block" do %>
+                  <% full_address = shop.address.to_s.strip %>
                   <p class="text-sm font-semibold line-clamp-2 group-hover:underline"><%= shop.name %></p>
                   <div class="mt-2 text-xs text-slate-600 space-y-1">
-                    <p>📍 <%= [shop.prefecture, shop.city].compact.join %></p>
+                    <p>📍 <%= full_address.presence || "住所未設定" %></p>
                     <p class="text-slate-500">登録者: <%= shop.user&.name %></p>
                   </div>
                 <% end %>

--- a/app/views/shops/index.html.erb
+++ b/app/views/shops/index.html.erb
@@ -26,12 +26,10 @@
             </div>
             <%= link_to shop_path(shop),
                   class: "block bg-white rounded-xl shadow-sm p-4 hover:shadow-md transition" do %>
+              <% full_address = shop.address.to_s.strip %>
               <p class="text-sm font-semibold mb-1"><%= shop.name %></p>
-              <p class="text-xs text-slate-500 mb-1">
-                <%= [shop.prefecture, shop.city].compact.join %>
-              </p>
               <p class="text-xs text-slate-500">
-                <%= shop.address %>
+                <%= full_address.presence || "住所未設定" %>
               </p>
             <% end %>
           </div>

--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -48,15 +48,17 @@
           <% end %>
         </div>
 
+        <% full_address = @shop.address.to_s.strip %>
+
         <div class="space-y-2 text-sm text-slate-700 mb-4">
           <% if @shop.postal_code.present? %>
             <p><span class="font-medium">郵便番号：</span><%= @shop.postal_code %></p>
           <% end %>
 
-          <% if @shop.prefecture.present? || @shop.city.present? || @shop.address.present? %>
+          <% if full_address.present? %>
             <p>
               <span class="font-medium">住所：</span>
-              <%= [@shop.prefecture, @shop.city, @shop.address].compact.join %>
+              <%= full_address %>
             </p>
           <% end %>
 


### PR DESCRIPTION
## 概要
イベントとショップの住所表示で参照元が混在していたため、`shop.address` 基準に統一しました。
住所重複表示（prefecture/city/address の連結由来）も解消しています。

## 変更内容
- イベント詳細の住所/地図参照を `event.shop.address` に統一
- イベント確認画面の住所/地図参照を `event.shop.address` に統一
- イベントカードの住所表示を `event.shop.address` に統一
- ショップ詳細の住所表示を `shop.address` 単独表示に変更
- ショップ一覧の住所表示を `shop.address` 単独表示に変更
- マイページのお気に入り店舗住所表示を `shop.address` 単独表示に変更

## 動作確認
- `docker compose exec -e RAILS_ENV=test web bundle exec rspec spec/requests/shops_spec.rb spec/requests/events_confirm_spec.rb spec/requests/events_create_permission_spec.rb`
- 結果: `9 examples, 0 failures`

## 期待効果
- イベント画面と店舗画面で住所表示の不一致が発生しない
- `address` に都道府県/市区町村が含まれるデータでも重複表示しない
