### PR TITLE
feat(notifications): Web Push通知の導入（購読API/送信基盤/イベント通知連携）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ gem "turbo-rails"
 gem "stimulus-rails"
 gem "jbuilder"
 gem "sassc-rails"
+gem "webpush"
+
 
 # Auth
 gem "bcrypt", "~> 3.1.7"

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "turbo-rails"
 gem "stimulus-rails"
 gem "jbuilder"
 gem "sassc-rails"
-gem "webpush"
+gem "web-push"
 
 
 # Auth

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,6 @@ GEM
       activesupport (>= 6.1)
     hashie (5.1.0)
       logger
-    hkdf (0.3.0)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     image_processing (1.14.0)
@@ -299,6 +298,7 @@ GEM
     omniauth-rails_csrf_protection (2.0.1)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
+    openssl (4.0.1)
     orm_adapter (0.5.0)
     parallel (1.27.0)
     parser (3.3.10.0)
@@ -504,9 +504,9 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webpush (0.3.2)
-      hkdf (~> 0.2)
-      jwt
+    web-push (3.1.0)
+      jwt (~> 3.0)
+      openssl (>= 3.0)
     websocket (1.2.11)
     websocket-driver (0.8.0)
       base64
@@ -572,7 +572,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
-  webpush
+  web-push
   whenever
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,6 +181,7 @@ GEM
       activesupport (>= 6.1)
     hashie (5.1.0)
       logger
+    hkdf (0.3.0)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     image_processing (1.14.0)
@@ -503,6 +504,9 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webpush (0.3.2)
+      hkdf (~> 0.2)
+      jwt
     websocket (1.2.11)
     websocket-driver (0.8.0)
       base64
@@ -568,6 +572,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  webpush
   whenever
 
 BUNDLED WITH

--- a/app/controllers/push_subscriptions_controller.rb
+++ b/app/controllers/push_subscriptions_controller.rb
@@ -1,0 +1,43 @@
+class PushSubscriptionsController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    subscription = PushSubscription.find_or_initialize_by(endpoint: push_subscription_params[:endpoint])
+    subscription.user = current_user
+    subscription.assign_attributes(push_subscription_params.except(:endpoint))
+
+    if subscription.save
+      status = subscription.previously_new_record? ? :created : :ok
+      render json: { id: subscription.id }, status: status
+    else
+      render json: { errors: subscription.errors.full_messages }, status: :unprocessable_content
+    end
+  end
+
+  def destroy
+    endpoint = destroy_endpoint
+    return render json: { errors: [ "endpoint is required" ] }, status: :bad_request if endpoint.blank?
+
+    subscription = current_user.push_subscriptions.find_by(endpoint: endpoint)
+    return head :no_content unless subscription
+
+    subscription.destroy!
+    head :no_content
+  end
+
+  private
+
+  def push_subscription_params
+    params.require(:push_subscription).permit(
+      :endpoint,
+      :p256dh,
+      :auth,
+      :expiration_time,
+      :user_agent
+    )
+  end
+
+  def destroy_endpoint
+    params[:endpoint].presence || params.dig(:push_subscription, :endpoint)
+  end
+end

--- a/app/controllers/push_subscriptions_controller.rb
+++ b/app/controllers/push_subscriptions_controller.rb
@@ -2,13 +2,23 @@ class PushSubscriptionsController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    subscription = PushSubscription.find_or_initialize_by(endpoint: push_subscription_params[:endpoint])
-    subscription.user = current_user
-    subscription.assign_attributes(push_subscription_params.except(:endpoint))
+    subscription = PushSubscription.find_by(endpoint: push_subscription_params[:endpoint])
 
-    if subscription.save
-      status = subscription.previously_new_record? ? :created : :ok
-      render json: { id: subscription.id }, status: status
+    if subscription.nil?
+      new_subscription = current_user.push_subscriptions.build(push_subscription_params)
+      if new_subscription.save
+        return render json: { id: new_subscription.id }, status: :created
+      end
+
+      return render json: { errors: new_subscription.errors.full_messages }, status: :unprocessable_content
+    end
+
+    if subscription.user_id != current_user.id
+      return render json: { errors: [ "endpoint is already registered by another user" ] }, status: :conflict
+    end
+
+    if subscription.update(push_subscription_params.except(:endpoint))
+      render json: { id: subscription.id }, status: :ok
     else
       render json: { errors: subscription.errors.full_messages }, status: :unprocessable_content
     end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -5,3 +5,4 @@ import "@hotwired/turbo-rails"
 import "./controllers"
 import * as ActiveStorage from "@rails/activestorage"
 ActiveStorage.start()
+import "./push_subscription"

--- a/app/javascript/push_subscription.js
+++ b/app/javascript/push_subscription.js
@@ -1,0 +1,71 @@
+function csrfToken() {
+  return document.querySelector('meta[name="csrf-token"]')?.content;
+}
+
+function vapidPublicKey() {
+  return document.querySelector('meta[name="vapid-public-key"]')?.content;
+}
+
+function urlBase64ToUint8Array(base64String) {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = window.atob(base64);
+  return Uint8Array.from([...raw].map((char) => char.charCodeAt(0)));
+}
+
+async function saveSubscription(subscription) {
+  const json = subscription.toJSON();
+  const response = await fetch("/push_subscription", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-CSRF-Token": csrfToken()
+    },
+    credentials: "same-origin",
+    body: JSON.stringify({
+      push_subscription: {
+        endpoint: subscription.endpoint,
+        p256dh: json.keys?.p256dh,
+        auth: json.keys?.auth,
+        expiration_time: subscription.expirationTime,
+        user_agent: navigator.userAgent
+      }
+    })
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`push_subscription save failed: ${response.status} ${body}`);
+  }
+}
+
+async function ensurePushSubscription() {
+  if (document.body.dataset.signedIn !== "true") return;
+  if (!("serviceWorker" in navigator)) return;
+  if (!("PushManager" in window)) return;
+  if (!("Notification" in window)) return;
+
+  const vapid = vapidPublicKey();
+  if (!vapid) return;
+
+  const registration = await navigator.serviceWorker.register("/service-worker");
+
+  const permission = await Notification.requestPermission();
+  if (permission !== "granted") return;
+
+  let subscription = await registration.pushManager.getSubscription();
+  if (!subscription) {
+    subscription = await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(vapid)
+    });
+  }
+
+  await saveSubscription(subscription);
+}
+
+document.addEventListener("turbo:load", () => {
+  ensurePushSubscription().catch((error) => {
+    console.error("[push] subscription setup failed", error);
+  });
+});

--- a/app/jobs/push_notification_job.rb
+++ b/app/jobs/push_notification_job.rb
@@ -1,0 +1,10 @@
+class PushNotificationJob < ApplicationJob
+  queue_as :default
+  # 購読解除済みなどでレコードが消えていたら静かに終了
+  discard_on ActiveRecord::RecordNotFound
+
+  def perform(push_subscription_id, payload)
+    subscription = PushSubscription.find(push_subscription_id)
+    PushNotifications::SendService.call(subscription:, payload:)
+  end
+end

--- a/app/models/push_subscription.rb
+++ b/app/models/push_subscription.rb
@@ -1,0 +1,6 @@
+class PushSubscription < ApplicationRecord
+  belongs_to :user
+
+  validates :endpoint, :p256dh, :auth, presence: true
+  validates :endpoint, uniqueness: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,8 @@ class User < ApplicationRecord
             foreign_key: :recipient_id,
             dependent: :destroy
 
+  has_many :push_subscriptions, dependent: :destroy
+
   enum :pro_player_status, { unapplied: 0, pending: 1, approved: 2, rejected: 3 }, default: :unapplied
 
   validates :pro_sns_url, presence: true, if: -> { pro_player_status == "pending" }

--- a/app/services/notifications/event_notification_service.rb
+++ b/app/services/notifications/event_notification_service.rb
@@ -11,7 +11,7 @@ module Notifications
     def notify_event_created!
       recipients = recipients_with_reason_for_event_created
 
-      # recipients（送信対象）を先に集計し、Userは一括取得してN+1を避ける
+      # メール通知, recipients（送信対象）を先に集計し、Userは一括取得してN+1を避ける
       users_by_id = User.where(id: recipients.keys).index_by(&:id)
 
       recipients.each do |user_id, notification_context|
@@ -20,6 +20,9 @@ module Notifications
 
         event_created!(recipient, notification_context)
       end
+
+      # Push通知
+      enqueue_push_notifications(recipients.keys)
     end
 
     def recipients_with_reason_for_event_created
@@ -99,6 +102,30 @@ module Notifications
 
     def base_context
       { reasons: [], pro_names: [], shop_name: event.shop.name }
+    end
+
+    def enqueue_push_notifications(user_ids)
+      ids = Array(user_ids).uniq
+      return if ids.blank?
+
+      PushNotifications::FanoutService.call(
+        user_ids: ids,
+        payload: build_push_payload
+      )
+    rescue => e
+      Rails.logger.error(
+        "[push] enqueue failed event_id=#{event.id} user_ids=#{user_ids.join(',')} #{e.class} #{e.message}"
+      )
+      Sentry.capture_exception(e) if defined?(Sentry)
+    end
+
+    def build_push_payload
+      {
+        title: "新しいイベントが投稿されました",
+        body: "#{event.shop.name} / #{event.title}",
+        url: Rails.application.routes.url_helpers.event_path(event),
+        tag: "event-#{event.id}"
+      }
     end
   end
 end

--- a/app/services/push_notifications/fanout_service.rb
+++ b/app/services/push_notifications/fanout_service.rb
@@ -1,0 +1,22 @@
+module PushNotifications
+  class FanoutService
+    def self.call(user_ids:, payload:)
+      new(user_ids:, payload:).call
+    end
+
+    def initialize(user_ids:, payload:)
+      @user_ids = user_ids
+      @payload = payload
+    end
+
+    def call
+      PushSubscription.where(user_id: user_ids).find_each do |subscription|
+        PushNotificationJob.perform_later(subscription.id, payload)
+      end
+    end
+
+    private
+
+    attr_reader :user_ids, :payload
+  end
+end

--- a/app/services/push_notifications/send_service.rb
+++ b/app/services/push_notifications/send_service.rb
@@ -1,0 +1,43 @@
+module PushNotifications
+  class SendService
+    def self.call(subscription:, payload:)
+      new(subscription:, payload:).call
+    end
+
+    def initialize(subscription:, payload:)
+      @subscription = subscription
+      @payload = payload
+    end
+
+    def call
+      WebPush.payload_send(
+        message: payload.to_json,
+        endpoint: subscription.endpoint,
+        p256dh: subscription.p256dh,
+        auth: subscription.auth,
+        vapid: {
+          subject: Rails.configuration.x.webpush.subject,
+          public_key: Rails.configuration.x.webpush.public_key,
+          private_key: Rails.configuration.x.webpush.private_key
+        }
+      )
+      :ok
+    rescue WebPush::ExpiredSubscription, WebPush::InvalidSubscription
+      subscription.destroy!
+      :stale_deleted
+    rescue WebPush::ResponseError => e
+      # gemバージョン差があるので status 取得は実ログで確認して調整
+      status = e.respond_to?(:response) ? e.response&.status.to_i : nil
+      if [ 404, 410 ].include?(status)
+        subscription.destroy!
+        :stale_deleted
+      else
+        raise
+      end
+    end
+
+    private
+
+    attr_reader :subscription, :payload
+  end
+end

--- a/app/services/push_notifications/send_service.rb
+++ b/app/services/push_notifications/send_service.rb
@@ -10,7 +10,7 @@ module PushNotifications
     end
 
     def call
-      WebPush.payload_send(
+      Webpush.payload_send(
         message: payload.to_json,
         endpoint: subscription.endpoint,
         p256dh: subscription.p256dh,
@@ -22,10 +22,10 @@ module PushNotifications
         }
       )
       :ok
-    rescue WebPush::ExpiredSubscription, WebPush::InvalidSubscription
+    rescue Webpush::ExpiredSubscription, Webpush::InvalidSubscription
       subscription.destroy!
       :stale_deleted
-    rescue WebPush::ResponseError => e
+    rescue Webpush::ResponseError => e
       # gemバージョン差があるので status 取得は実ログで確認して調整
       status = e.respond_to?(:response) ? e.response&.status.to_i : nil
       if [ 404, 410 ].include?(status)

--- a/app/services/push_notifications/send_service.rb
+++ b/app/services/push_notifications/send_service.rb
@@ -10,7 +10,7 @@ module PushNotifications
     end
 
     def call
-      Webpush.payload_send(
+      WebPush.payload_send(
         message: payload.to_json,
         endpoint: subscription.endpoint,
         p256dh: subscription.p256dh,
@@ -22,10 +22,10 @@ module PushNotifications
         }
       )
       :ok
-    rescue Webpush::ExpiredSubscription, Webpush::InvalidSubscription
+    rescue WebPush::ExpiredSubscription, WebPush::InvalidSubscription
       subscription.destroy!
       :stale_deleted
-    rescue Webpush::ResponseError => e
+    rescue WebPush::ResponseError => e
       # gemバージョン差があるので status 取得は実ログで確認して調整
       status = e.respond_to?(:response) ? e.response&.status.to_i : nil
       if [ 404, 410 ].include?(status)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,9 @@
     <meta name="twitter:image" content="<%= "#{request.base_url}/ogp.png" %>">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <% if Rails.configuration.x.webpush.public_key.present? %>
+      <meta name="vapid-public-key" content="<%= Rails.configuration.x.webpush.public_key %>">
+    <% end %>
 
     <%= yield :head %>
 
@@ -29,7 +32,7 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body class="min-h-screen flex flex-col">
+  <body class="min-h-screen flex flex-col" data-signed-in="<%= user_signed_in? %>">
     <%= render "shared/header" unless @disable_header %>
     <% unless @disable_flash %>
       <%= render "shared/flash" %>

--- a/app/views/pwa/service-worker.js
+++ b/app/views/pwa/service-worker.js
@@ -1,26 +1,35 @@
-// Add a service worker for processing Web Push notifications:
-//
-// self.addEventListener("push", async (event) => {
-//   const { title, options } = await event.data.json()
-//   event.waitUntil(self.registration.showNotification(title, options))
-// })
-//
-// self.addEventListener("notificationclick", function(event) {
-//   event.notification.close()
-//   event.waitUntil(
-//     clients.matchAll({ type: "window" }).then((clientList) => {
-//       for (let i = 0; i < clientList.length; i++) {
-//         let client = clientList[i]
-//         let clientPath = (new URL(client.url)).pathname
-//
-//         if (clientPath == event.notification.data.path && "focus" in client) {
-//           return client.focus()
-//         }
-//       }
-//
-//       if (clients.openWindow) {
-//         return clients.openWindow(event.notification.data.path)
-//       }
-//     })
-//   )
-// })
+self.addEventListener("push", (event) => {
+  let data = {};
+  try {
+    data = event.data ? event.data.json() : {};
+  } catch (_e) {
+    data = {};
+  }
+
+  const title = data.title || "Darts Events";
+  const body = data.body || "新しいお知らせがあります";
+  const url = data.url || "/";
+  const targetUrl = new URL(url, self.location.origin).toString();
+
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body,
+      tag: data.tag || "default",
+      data: { url: targetUrl }
+    })
+  );
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const targetUrl = event.notification.data?.url || self.location.origin;
+
+  event.waitUntil(
+    clients.matchAll({ type: "window", includeUncontrolled: true }).then((clientList) => {
+      for (const client of clientList) {
+        if (client.url === targetUrl && "focus" in client) return client.focus();
+      }
+      if (clients.openWindow) return clients.openWindow(targetUrl);
+    })
+  );
+});

--- a/compose.yml
+++ b/compose.yml
@@ -27,8 +27,6 @@ services:
       - node_modules:/myapp/node_modules
     environment:
       TZ: Asia/Tokyo
-      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
     ports:
       - "3000:3000"
     depends_on:

--- a/config/initializers/webpush.rb
+++ b/config/initializers/webpush.rb
@@ -1,0 +1,6 @@
+Rails.application.configure do
+  config.x.webpush = ActiveSupport::OrderedOptions.new
+  config.x.webpush.public_key  = ENV["VAPID_PUBLIC_KEY"]
+  config.x.webpush.private_key = ENV["VAPID_PRIVATE_KEY"]
+  config.x.webpush.subject     = ENV["VAPID_SUBJECT"] # 例: mailto:admin@example.com
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resource :push_subscription, only: %i[create destroy]
+
   get "up" => "rails/health#show", as: :rails_health_check
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest

--- a/db/migrate/20260404225345_create_push_subscriptions.rb
+++ b/db/migrate/20260404225345_create_push_subscriptions.rb
@@ -1,0 +1,15 @@
+class CreatePushSubscriptions < ActiveRecord::Migration[7.2]
+  def change
+    create_table :push_subscriptions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.text :endpoint, null: false
+      t.string :p256dh, null: false
+      t.string :auth, null: false
+      t.datetime :expiration_time
+      t.string :user_agent
+      t.timestamps
+    end
+
+    add_index :push_subscriptions, :endpoint, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_03_13_231909) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_04_225345) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -117,6 +117,19 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_13_231909) do
     t.index ["recipient_id"], name: "index_notifications_on_recipient_id"
   end
 
+  create_table "push_subscriptions", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.text "endpoint", null: false
+    t.string "p256dh", null: false
+    t.string "auth", null: false
+    t.datetime "expiration_time"
+    t.string "user_agent"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["endpoint"], name: "index_push_subscriptions_on_endpoint", unique: true
+    t.index ["user_id"], name: "index_push_subscriptions_on_user_id"
+  end
+
   create_table "shops", force: :cascade do |t|
     t.string "name", null: false
     t.text "description"
@@ -184,5 +197,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_13_231909) do
   add_foreign_key "favorites", "users"
   add_foreign_key "notifications", "users", column: "actor_id"
   add_foreign_key "notifications", "users", column: "recipient_id"
+  add_foreign_key "push_subscriptions", "users"
   add_foreign_key "shops", "users"
 end

--- a/spec/factories/push_subscriptions.rb
+++ b/spec/factories/push_subscriptions.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :push_subscription do
+    user { nil }
+    endpoint { "MyText" }
+    p256dh { "MyString" }
+    auth { "MyString" }
+    expiration_time { "2026-04-05 07:53:45" }
+    user_agent { "MyString" }
+  end
+end

--- a/spec/models/push_subscription_spec.rb
+++ b/spec/models/push_subscription_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe PushSubscription, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/push_subscription_spec.rb
+++ b/spec/models/push_subscription_spec.rb
@@ -1,5 +1,25 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe PushSubscription, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:user) { create(:user) }
+
+  subject(:push_subscription) { build(:push_subscription, user: user) }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:user) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:endpoint) }
+    it { is_expected.to validate_presence_of(:p256dh) }
+    it { is_expected.to validate_presence_of(:auth) }
+
+    it "validates uniqueness of endpoint" do
+      create(:push_subscription, user: user, endpoint: "https://example.push.endpoint/unique")
+      duplicate = build(:push_subscription, user: create(:user), endpoint: "https://example.push.endpoint/unique")
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors.of_kind?(:endpoint, :taken)).to be(true)
+    end
+  end
 end

--- a/spec/requests/push_subscriptions_spec.rb
+++ b/spec/requests/push_subscriptions_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+RSpec.describe "Push subscriptions", type: :request do
+  let(:user) { create(:user) }
+
+  describe "未ログイン" do
+    let(:params) do
+      {
+        push_subscription: {
+          endpoint: "https://example.push.endpoint/abc",
+          p256dh: "p256dh_key",
+          auth: "auth_key"
+        }
+      }
+    end
+    it "createできずログイン画面へリダイレクトされる" do
+      expect {
+        post push_subscription_path, params: params
+      }.not_to change(PushSubscription, :count)
+
+      expect(response).to have_http_status(:found)
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+  describe "POST /push_subscription" do
+    before { sign_in user }
+
+    let(:params) do
+      {
+        push_subscription: {
+        endpoint:"https://example.push.endpoint/abc",
+        p256dh: "p256dh_key",
+        auth: "auth_key",
+        user_agent: "RSpec"
+        }
+      }
+    end
+
+    it "初回のPush購読を登録できる" do
+      expect {
+        post push_subscription_path, params: params
+      }.to change(PushSubscription, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      expect(PushSubscription.last.user).to eq(user)
+    end
+
+    it "同じendpointで再登録したとき重複作成しない" do
+      create(:push_subscription, user: user, endpoint: params[:push_subscription][:endpoint])
+
+      expect {
+        post push_subscription_path, params: params
+      }.not_to change(PushSubscription, :count)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "DELETE /push_subscription" do
+    before { sign_in user }
+
+    it "ログインユーザーは自分のPush購読を解除できる" do
+      subscription = create(:push_subscription, user: user, endpoint: "https://example.push.endpoint/delete-me")
+
+      expect {
+        delete push_subscription_path, params: { endpoint: subscription.endpoint }
+      }.to change(PushSubscription, :count).by(-1)
+
+      expect(response).to have_http_status(:no_content)
+    end
+  end
+end

--- a/spec/requests/push_subscriptions_spec.rb
+++ b/spec/requests/push_subscriptions_spec.rb
@@ -28,10 +28,10 @@ RSpec.describe "Push subscriptions", type: :request do
     let(:params) do
       {
         push_subscription: {
-        endpoint:"https://example.push.endpoint/abc",
-        p256dh: "p256dh_key",
-        auth: "auth_key",
-        user_agent: "RSpec"
+          endpoint: "https://example.push.endpoint/abc",
+          p256dh: "p256dh_key",
+          auth: "auth_key",
+          user_agent: "RSpec"
         }
       }
     end
@@ -53,6 +53,28 @@ RSpec.describe "Push subscriptions", type: :request do
       }.not_to change(PushSubscription, :count)
 
       expect(response).to have_http_status(:ok)
+    end
+
+    it "他ユーザーが所有するendpointを再登録すると409を返し、所有者を変えない" do
+      other_user = create(:user)
+      existing = create(
+        :push_subscription,
+        user: other_user,
+        endpoint: params[:push_subscription][:endpoint],
+        p256dh: "old_p256dh",
+        auth: "old_auth"
+      )
+
+      expect {
+        post push_subscription_path, params: params
+      }.not_to change(PushSubscription, :count)
+
+      expect(response).to have_http_status(:conflict)
+
+      existing.reload
+      expect(existing.user).to eq(other_user)
+      expect(existing.p256dh).to eq("old_p256dh")
+      expect(existing.auth).to eq("old_auth")
     end
   end
 

--- a/spec/services/notifications/event_notification_service_spec.rb
+++ b/spec/services/notifications/event_notification_service_spec.rb
@@ -24,4 +24,41 @@ RSpec.describe Notifications::EventNotificationService, type: :service do
     expect(result).to eq(:failed)
     expect(Sentry).to have_received(:capture_exception)
   end
+  describe "#notify_event_created!" do
+    it "Push配信対象があるとき FanoutService を呼び出す" do
+      service = described_class.new(event, actor: actor)
+      recipients = { recipient.id => context }
+
+      allow(service).to receive(:recipients_with_reason_for_event_created).and_return(recipients)
+      allow(service).to receive(:event_created!).and_return(:sent)
+
+      expect(PushNotifications::FanoutService).to receive(:call).with(
+        user_ids: [recipient.id],
+        payload: hash_including(
+          title: "新しいイベントが投稿されました",
+          body: "#{shop.name} / #{event.title}",
+          url: Rails.application.routes.url_helpers.event_path(event),
+          tag: "event-#{event.id}"
+        )
+      )
+
+      service.notify_event_created!
+    end
+
+    it "Push enqueueで例外が起きても notify_event_created! は落ちない" do
+      service = described_class.new(event, actor: actor)
+      recipients = { recipient.id => context }
+
+      allow(service).to receive(:recipients_with_reason_for_event_created).and_return(recipients)
+      allow(service).to receive(:event_created!).and_return(:sent)
+      allow(PushNotifications::FanoutService).to receive(:call).and_raise(StandardError, "push enqueue failed")
+      allow(Rails.logger).to receive(:error)
+
+      stub_const("Sentry", Class.new) unless defined?(Sentry)
+      allow(Sentry).to receive(:capture_exception)
+
+      expect { service.notify_event_created! }.not_to raise_error
+      expect(Sentry).to have_received(:capture_exception)
+    end
+  end
 end

--- a/spec/services/notifications/event_notification_service_spec.rb
+++ b/spec/services/notifications/event_notification_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Notifications::EventNotificationService, type: :service do
       allow(service).to receive(:event_created!).and_return(:sent)
 
       expect(PushNotifications::FanoutService).to receive(:call).with(
-        user_ids: [recipient.id],
+        user_ids: [ recipient.id ],
         payload: hash_including(
           title: "新しいイベントが投稿されました",
           body: "#{shop.name} / #{event.title}",

--- a/spec/services/push_notifications/send_service_spec.rb
+++ b/spec/services/push_notifications/send_service_spec.rb
@@ -1,0 +1,106 @@
+require "rails_helper"
+
+RSpec.describe PushNotifications::SendService, type: :service do
+  let(:user) { create(:user) }
+  let!(:subscription) do
+    create(
+      :push_subscription,
+      user: user,
+      endpoint: "https://example.push.endpoint/send-service",
+      p256dh: "test_p256dh",
+      auth: "test_auth"
+    )
+  end
+  let(:payload) { { title: "title", body: "body", url: "/events/1", tag: "event-1" } }
+
+  describe ".call" do
+    it "正常時は :ok を返す" do
+      allow(WebPush).to receive(:payload_send).and_return(true)
+
+      result = described_class.call(subscription: subscription, payload: payload)
+
+      expect(result).to eq(:ok)
+      expect(WebPush).to have_received(:payload_send).with(
+        hash_including(
+          message: payload.to_json,
+          endpoint: subscription.endpoint,
+          p256dh: subscription.p256dh,
+          auth: subscription.auth,
+          vapid: hash_including(:subject, :public_key, :private_key)
+        )
+      )
+    end
+
+    it "ExpiredSubscription発生時は購読を削除して :stale_deleted を返す" do
+      stub_const("WebPush::ExpiredSubscription", Class.new(StandardError))
+      allow(WebPush).to receive(:payload_send).and_raise(WebPush::ExpiredSubscription, "expired")
+
+      result = nil
+      expect {
+        result = described_class.call(subscription: subscription, payload: payload)
+      }.to change(PushSubscription, :count).by(-1)
+
+      expect(result).to eq(:stale_deleted)
+    end
+
+    it "InvalidSubscription発生時は購読を削除して :stale_deleted を返す" do
+      stub_const("WebPush::InvalidSubscription", Class.new(StandardError))
+      allow(WebPush).to receive(:payload_send).and_raise(WebPush::InvalidSubscription, "invalid")
+
+      result = nil
+      expect {
+        result = described_class.call(subscription: subscription, payload: payload)
+      }.to change(PushSubscription, :count).by(-1)
+
+      expect(result).to eq(:stale_deleted)
+    end
+
+    context "ResponseError のとき" do
+      let(:response_error_class) do
+        Class.new(StandardError) do
+          attr_reader :response
+
+          def initialize(status)
+            @response = Struct.new(:status).new(status)
+            super("response error")
+          end
+        end
+      end
+
+      before do
+        stub_const("WebPush::ResponseError", response_error_class)
+      end
+
+      it "HTTP 404 は購読を削除して :stale_deleted を返す" do
+        allow(WebPush).to receive(:payload_send).and_raise(WebPush::ResponseError.new(404))
+
+        result = nil
+        expect {
+          result = described_class.call(subscription: subscription, payload: payload)
+        }.to change(PushSubscription, :count).by(-1)
+
+        expect(result).to eq(:stale_deleted)
+      end
+
+      it "HTTP 410 は購読を削除して :stale_deleted を返す" do
+        allow(WebPush).to receive(:payload_send).and_raise(WebPush::ResponseError.new(410))
+
+        result = nil
+        expect {
+          result = described_class.call(subscription: subscription, payload: payload)
+        }.to change(PushSubscription, :count).by(-1)
+
+        expect(result).to eq(:stale_deleted)
+      end
+
+      it "HTTP 500 は例外を再送出し、購読は削除しない" do
+        allow(WebPush).to receive(:payload_send).and_raise(WebPush::ResponseError.new(500))
+
+        expect {
+          described_class.call(subscription: subscription, payload: payload)
+        }.to raise_error(WebPush::ResponseError)
+        expect(PushSubscription.exists?(subscription.id)).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
Web Push通知を段階導入しました。
既存のアプリ内通知・メール通知は維持しつつ、イベント作成通知をWeb Pushでも配信できるようにしています。

## 変更内容
- `push_subscriptions` テーブル追加（endpointユニーク）
- `PushSubscription` モデル追加（`belongs_to :user` / 必須バリデーション）
- 購読API追加
  - `POST /push_subscription`
  - `DELETE /push_subscription`
- endpoint所有境界を固定
  - 未登録endpoint: 201で新規作成
  - 同一ユーザー再登録: 200で更新
  - 別ユーザー再登録: 409で拒否（所有者上書き防止）
- フロント側の購読登録実装
  - Service Worker登録
  - 通知許可取得
  - Push購読取得
  - 購読情報をAPIへ保存
- Push送信基盤を追加
  - `PushNotifications::SendService`
  - `PushNotifications::FanoutService`
  - `PushNotificationJob`
- イベント通知フローにPush enqueueを接続
  - enqueue失敗時はイベント作成全体を落とさずログ/Sentry記録
- VAPID鍵の設定初期化追加（ENV参照）

## テスト
以下を実行して green を確認:
- `spec/models/push_subscription_spec.rb`
- `spec/requests/push_subscriptions_spec.rb`
- `spec/services/push_notifications/send_service_spec.rb`
- `spec/services/notifications/event_notification_service_spec.rb`

実行結果:
- 19 examples, 0 failures